### PR TITLE
feature(talks): Add talks page with video embeds

### DIFF
--- a/components/PageHeader.tsx
+++ b/components/PageHeader.tsx
@@ -19,6 +19,13 @@ const PageHeader = () => {
             >
               Blog
             </Link>
+            <p className="text-slate-300">-</p>
+            <Link
+              href="/talks"
+              className="text-lg text-slate-300 hover:underline"
+            >
+              Talks
+            </Link>
           </div>
         </div>
       </div>

--- a/components/TalkMetadata.ts
+++ b/components/TalkMetadata.ts
@@ -1,0 +1,7 @@
+export interface TalkMetadata {
+  title: string;
+  date: string;
+  description: string;
+  videoUrl: string;
+  slug: string;
+}

--- a/components/TalkPreview.tsx
+++ b/components/TalkPreview.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { TalkMetadata } from "./TalkMetadata";
+
+const TalkPreview = (props: TalkMetadata) => {
+  return (
+    <div
+      key={props.slug}
+      className="border border-slate-200 p-4 rounded-md shadow-md bg-white"
+    >
+      <Link href={`/talks/talks/${props.slug}`}>
+        <h2 className="font-bold text-slate-600 hover:underline">
+          {props.title}
+        </h2>
+      </Link>
+      <p className="text-sm text-slate-400">
+        {new Date(props.date).toLocaleDateString("en-US", {
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+        })}
+      </p>
+      <p className="text-slate-700">{props.description}</p>
+    </div>
+  );
+};
+
+export default TalkPreview;

--- a/components/getTalkMetadata.ts
+++ b/components/getTalkMetadata.ts
@@ -1,0 +1,28 @@
+import { TalkMetadata } from "./TalkMetadata";
+import fs from "fs";
+import matter from "gray-matter";
+
+const getTalkMetadata = (): TalkMetadata[] => {
+  const folder = "talks/";
+  const files = fs.readdirSync(folder);
+  const markdownTalkSummaries = files.filter((file) => file.endsWith(".md"));
+
+  // Get front-matter for each post
+  const talks = markdownTalkSummaries.map((fileName) => {
+    const fileContents = fs.readFileSync(`talks/${fileName}`, "utf8");
+    const matterResult = matter(fileContents);
+
+    return {
+      title: matterResult.data.title,
+      description: matterResult.data.description,
+      date: matterResult.data.date,
+      videoUrl: matterResult.data.videoUrl,
+      slug: fileName.replace(".md", ""),
+    };
+  });
+
+  talks.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  return talks;
+};
+
+export default getTalkMetadata;

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -8,7 +8,14 @@ const BlogIndex = () => {
   ));
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">{postPreviews}</div>
+    <div className="flex flex-col space-y-4">
+      <h2 className="text-4xl font-bold text-slate-800 text-center">
+        Blog Posts
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {postPreviews}
+      </div>
+    </div>
   );
 };
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import getPostMetadata from "../../../components/getPostMetadata";
 import PostPreview from "../../../components/PostPreview";
 

--- a/src/app/talks/page.tsx
+++ b/src/app/talks/page.tsx
@@ -8,7 +8,12 @@ const TalksIndex = () => {
   ));
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">{talkPreviews}</div>
+    <div className="flex flex-col space-y-4">
+      <h2 className="text-4xl font-bold text-slate-800 text-center">Talks</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {talkPreviews}
+      </div>
+    </div>
   );
 };
 

--- a/src/app/talks/page.tsx
+++ b/src/app/talks/page.tsx
@@ -1,3 +1,6 @@
+import getTalkMetadata from "../../../components/getTalkMetadata";
+import TalkPreview from "../../../components/TalkPreview";
+
 const TalksIndex = () => {
   const talkMetadata = getTalkMetadata();
   const talkPreviews = talkMetadata.map((talk) => (

--- a/src/app/talks/talks/[slug]/page.tsx
+++ b/src/app/talks/talks/[slug]/page.tsx
@@ -21,8 +21,9 @@ export const generateStaticParams = async () => {
 const TalkPage = (props: any) => {
   const slug = props.params.slug;
   const talk = getTalkContent(slug);
+
   return (
-    <div>
+    <div className="flex flex-col items-center">
       <div className="my-12 text-center">
         <h1 className="text-4xl text-slate-900 font-bold">{talk.data.title}</h1>
         <p className="text-slate-400 mt-4 text-xl">
@@ -34,6 +35,14 @@ const TalkPage = (props: any) => {
         </p>
       </div>
 
+      <iframe
+        width="540"
+        height="315"
+        src={talk.data.videoUrl}
+        title={talk.data.title}
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowFullScreen
+      ></iframe>
       <article className="prose lg:prose-xl">
         <Markdown>{talk.content}</Markdown>
       </article>

--- a/src/app/talks/talks/[slug]/page.tsx
+++ b/src/app/talks/talks/[slug]/page.tsx
@@ -1,0 +1,44 @@
+import fs from "fs";
+import Markdown from "markdown-to-jsx";
+import matter from "gray-matter";
+import getTalkMetadata from "../../../../../components/getTalkMetadata";
+
+const getTalkContent = (slug: string) => {
+  const folder = "talks/";
+  const file = `${folder}${slug}.md`;
+  const content = fs.readFileSync(file, "utf8");
+  const matterResult = matter(content);
+  return matterResult;
+};
+
+export const generateStaticParams = async () => {
+  const talks = getTalkMetadata();
+  return talks.map((talk) => ({
+    slug: talk.slug,
+  }));
+};
+
+const TalkPage = (props: any) => {
+  const slug = props.params.slug;
+  const talk = getTalkContent(slug);
+  return (
+    <div>
+      <div className="my-12 text-center">
+        <h1 className="text-4xl text-slate-900 font-bold">{talk.data.title}</h1>
+        <p className="text-slate-400 mt-4 text-xl">
+          {new Date(talk.data.date).toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          })}
+        </p>
+      </div>
+
+      <article className="prose lg:prose-xl">
+        <Markdown>{talk.content}</Markdown>
+      </article>
+    </div>
+  );
+};
+
+export default TalkPage;

--- a/src/app/talks/talks/page.tsx
+++ b/src/app/talks/talks/page.tsx
@@ -1,0 +1,12 @@
+const TalksIndex = () => {
+  const talkMetadata = getTalkMetadata();
+  const talkPreviews = talkMetadata.map((talk) => (
+    <TalkPreview key={talk.slug} {...talk} />
+  ));
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">{talkPreviews}</div>
+  );
+};
+
+export default TalksIndex;

--- a/talks/elixirconf_2022_wrap_up.md
+++ b/talks/elixirconf_2022_wrap_up.md
@@ -1,0 +1,8 @@
+---
+title: ElixirConf 2022 Wrap Up
+description: I cover the highlights and major announcements from ElixirConf 2022 and share my experience with the rest of the Sydney Elixir community.
+videoUrl: "https://www.youtube.com/embed/yTx4g93RVGg?si=5jiQeNAK8JJi6K0m"
+date: "2022/09/27"
+---
+
+Transcript coming soon!

--- a/talks/i_learned_gleam_in_a_week.md
+++ b/talks/i_learned_gleam_in_a_week.md
@@ -1,0 +1,8 @@
+---
+title: I learned Gleam in a week - here's how it went
+description: I decided to learn Gleam in the span of a week and share my experience with other devs who also have an Elixir background.
+videoUrl: "https://www.youtube.com/embed/-8OIK4RIUsg?si=CKij81sgbihsGV5T"
+date: "2022/10/20"
+---
+
+Transcript Coming Soon!

--- a/talks/solving_freelancer_rates_in_gleam.md
+++ b/talks/solving_freelancer_rates_in_gleam.md
@@ -1,0 +1,8 @@
+---
+title: Solving Freelancer Rates on the Gleam Exercism track
+description: Exercism kindly invited me to stream a walkthrough of a solution to an exercise I wrote for the Gleam language track as part of Functional February!
+videoUrl: "https://www.youtube.com/embed/b-tPTDSFE_0?si=hwe_gFfrvf2J8TCY"
+date: "2023/03/15"
+---
+
+Transcript coming soon!

--- a/talks/testing_liveviews_a_beginners_guide.md
+++ b/talks/testing_liveviews_a_beginners_guide.md
@@ -1,0 +1,8 @@
+---
+title: Testing LiveViews - A Beginner's Guide
+description: I share my learnings through my trial-and-error journey into the world of testing LiveViews, and highlight some common pitfalls that may puzzle other beginners.
+videoUrl: "https://www.youtube.com/embed/4MyvGsp8pmI?si=PPxqsjEC3ohiyk14"
+date: "2022/06/15"
+---
+
+Transcript Coming Soon!

--- a/talks/wordle_elixir_flavour_elixirconf_2022.md
+++ b/talks/wordle_elixir_flavour_elixirconf_2022.md
@@ -1,0 +1,8 @@
+---
+title: Wordle, Elixir Flavour - ElixirConf 2022 Presentation
+description: I walk through how I learned to use Elixir, Phoenix and LiveView in a production environment by building a clone of the popular browser-based word game.
+videoURL: "https://youtu.be/Dvv5bZ8V1pM?si=ncR2Pwb9LiJzwYYG"
+date: "2022/09/03"
+---
+
+Transcript Coming Soon!

--- a/talks/wordle_elixir_flavour_elixirconf_2022.md
+++ b/talks/wordle_elixir_flavour_elixirconf_2022.md
@@ -1,7 +1,7 @@
 ---
 title: Wordle, Elixir Flavour - ElixirConf 2022 Presentation
 description: I walk through how I learned to use Elixir, Phoenix and LiveView in a production environment by building a clone of the popular browser-based word game.
-videoURL: "https://youtu.be/Dvv5bZ8V1pM?si=ncR2Pwb9LiJzwYYG"
+videoUrl: "https://www.youtube.com/embed/Dvv5bZ8V1pM?si=ncR2Pwb9LiJzwYYG"
 date: "2022/09/03"
 ---
 


### PR DESCRIPTION
- Adds a page for Talks with preview cards
- Renders each talk page with an embedded youtube video
- Adds a "Talks" link to the header nav
- Adds page titles for Talks and Blog to help users work out where they are